### PR TITLE
clean up as_rcdimple

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -23,6 +23,7 @@ Description: Create waffle charts (square pie charts)
 URL: http://github.com/hrbrmstr/waffle
 BugReports: https://github.com/hrbrmstr/waffle/issues
 Suggests:
+    rcdimple,
     testthat
 Depends:
     R (>= 3.0.0),
@@ -31,5 +32,4 @@ License: MIT + file LICENSE
 Imports:
     RColorBrewer,
     pipeR,
-    htmlwidgets,
-    rcdimple
+    htmlwidgets

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -5,18 +5,8 @@ Version: 0.2
 Date: 2015-03-18
 Author: Bob Rudis (@hrbrmstr)
 Authors@R: c(
-    person("John", "Kiernander", role = c("aut", "cph"), comment = "dimple.js
-      library in htmlwidgets/lib, https://github.com/PMSI-AlignAlytics/dimple"),
-    person("Mike", "Bostock", role = c("aut", "cph"), comment = "d3.js
-      library in htmlwidgets/lib, http://d3js.org"),
-    person("Jeremy", "Stucki", role = c("aut", "cph"), comment = "d3-grid
-      library in htmlwidgets/lib, http://github.com/cpettitt/dagre-d3"),
     person("Bob", "Rudis", role = c("aut", "cre"), comment = "R
       interface", email = "bob@rudis.net"),
-    person("Kenton", "Russell", role = c("aut", "cre"), comment = "rcdimple",
-      email = "kent.russell@timelyportfolio.com"),
-    person("Ramnath", "Vaidyanathan", role = c("aut","ctb"), comment = "rCharts
-      common interace functions", email = "ramnath.vaidya@gmail.com")
   )
 Maintainer: Bob Rudis <bob@rudis.net>
 Description: Create waffle charts (square pie charts)

--- a/R/waffle.R
+++ b/R/waffle.R
@@ -109,39 +109,50 @@ waffle <- function(parts, rows=10, xlab=NULL, title=NULL, colors=NA, size=2, fli
 #' Turn a ggplot waffle chart object into an htmlwidget
 #'
 #' Takes the output from \code{waffle} and turns it into an \code{rcdimple}
-#' \code{htmlwidget}.
+#' \code{htmlwidget}.  For this to work, you will need to install
+#' \code{rcdimple} with \code{devtools::install_github("timelyportfolio/rcdimple")}.
 #'
 #' @param wf waffle chart ggplot2 object
 #' @param height height of the resultant \code{htmlwidget}
 #' @param width width of the resultant \code{htmlwidget}
 #' @export
 as_rcdimple <- function( wf, height = NULL, width = NULL ){
-  ggplot_build(wf) %>>%
-    (.$data[[1]]) %>>%
-    ( data.frame(
-      group = wf$scales$scales[[3]]$labels[
-        match(wf$data$value,unique(wf$data$value))
+  # not import since optional dependency
+  #  check here to see if rcdimple is available
+  if(!require(rcdimple)) stop("please devtools::install_github('timelyportfolio/rcdimple')", call. = F)
+
+  # let ggplot2 do the work and build the chart
+  gb <- ggplot_build(wf)
+  dimp <- dimple(
+    na.omit(
+      data.frame(
+        group = wf$scales$scales[[3]]$labels[
+          match(wf$data$value,unique(wf$data$value))
         ]
-      , .
-      , stringAsFactors = F
-    ) ) %>>%
-    na.omit %>>%
-    (dat~
-       dimple( dat, y~x, type = "bar", groups = "group", width = width, height = height   ) %>>%
-       xAxis( type = "addCategoryAxis", title  = "" ) %>>%
-       yAxis( type = "addCategoryAxis", title = "" ) %>>%
-       default_colors( unique( dat$fill ) ) %>>%
-       add_title(wf$labels$title)
-    ) %>>%
-  tack( options = list(tasks = list(
-    htmlwidgets::JS(
-      'function(){
-          this.widgetDimple[0].axes.forEach(function(ax){
-            ax.shapes.remove()
-          })
-      }'
+        ,gb$data[[1]]
+        ,stringsAsFactors = F
+      )
     )
-  )))
+    , y~x
+    , type = "bar"
+    , groups = "group"
+    , width = width
+    , height = height
+    , xAxis = list( type = "addCategoryAxis", title  = "" )
+    , yAxis = list( type = "addCategoryAxis", title = "" )
+    , defaultColors = unique( na.omit(gb$data[[1]])$fill )
+    , title = list( text = wf$labels$title )
+    , tasks = list(
+        htmlwidgets::JS(
+          'function(){
+            this.widgetDimple[0].axes.forEach(function(ax){
+              ax.shapes.remove()
+            })
+          }'
+        )
+    )
+  )
+  return(dimp)
 }
 
 

--- a/R/waffle.R
+++ b/R/waffle.R
@@ -115,6 +115,13 @@ waffle <- function(parts, rows=10, xlab=NULL, title=NULL, colors=NA, size=2, fli
 #' @param wf waffle chart ggplot2 object
 #' @param height height of the resultant \code{htmlwidget}
 #' @param width width of the resultant \code{htmlwidget}
+#'
+#' @examples \dontrun{
+#'   # requires install of rcdimple
+#'   # devtools::install_github("timelyportfolio/rcdimple")
+#'   parts <- c( 80, 30, 20, 10 )
+#'   as_rcdimple( waffle( parts, rows=8) )
+#' }
 #' @export
 as_rcdimple <- function( wf, height = NULL, width = NULL ){
   # not import since optional dependency

--- a/man/as_rcdimple.Rd
+++ b/man/as_rcdimple.Rd
@@ -18,4 +18,12 @@ Takes the output from \code{waffle} and turns it into an \code{rcdimple}
 \code{htmlwidget}.  For this to work, you will need to install
 \code{rcdimple} with \code{devtools::install_github("timelyportfolio/rcdimple")}.
 }
+\examples{
+\dontrun{
+  # requires install of rcdimple
+  # devtools::install_github("timelyportfolio/rcdimple")
+  parts <- c( 80, 30, 20, 10 )
+  as_rcdimple( waffle( parts, rows=8) )
+}
+}
 

--- a/man/as_rcdimple.Rd
+++ b/man/as_rcdimple.Rd
@@ -15,6 +15,7 @@ as_rcdimple(wf, height = NULL, width = NULL)
 }
 \description{
 Takes the output from \code{waffle} and turns it into an \code{rcdimple}
-\code{htmlwidget}.
+\code{htmlwidget}.  For this to work, you will need to install
+\code{rcdimple} with \code{devtools::install_github("timelyportfolio/rcdimple")}.
 }
 


### PR DESCRIPTION
I changed `as_rcdimple()` that was introduced in #1 

1.  `Suggest` instead of `Import` the package `rcdimple`.  I think this should be an optional addon and should not force an install of `rcdimple` to work.  Also, no telling how long it will be for `rcdimple` to go to CRAN, so don't want to hold up a submission.
2.  Based on 1, remove the attribution generously added by @hrbrmstr in `DESCRIPTION`.
3.  pipe-less ; love the pipes but not yet in R base unfortunately so don't force on the non-pipers.
4.  Add a short example for documentation.

Everything seems to work as before.