### PR TITLE
fix misspelling of glyph

### DIFF
--- a/README.Rmd
+++ b/README.Rmd
@@ -26,7 +26,7 @@ The following functions are implemented:
 - Version `0.2.1` released - added Travis tests to ensure independent package build confirmation
 - Version `0.2.3` released - nulled many margins and made the use of `coord_equal` optional via the `equal` parameter
 - Version `0.3` released - added a `pad` parameter to `waffle` to make it easier to align plots; added `iron` to make it easier to do the alignment
-- Version `0.4` released - added `use_glphy` and `glpyh_size` to `waffle` so you can now make isotype pictograms
+- Version `0.4` released - added `use_glyph` and `glyph_size` to `waffle` so you can now make isotype pictograms
 
 ### Installation
 
@@ -85,7 +85,7 @@ waffle(parts/10, rows=3, colors=c("#969696", "#1879bf", "#009bda"))
 ```{r ww1, eval=FALSE}
 library(extrafont)
 waffle(parts/10, rows=3, colors=c("#969696", "#1879bf", "#009bda"),
-       use_glpyh="medkit", size=8)
+       use_glyph="medkit", size=8)
 ```
 
 ```{r ww2, echo=FALSE, fig.width=6, fig.height=2}


### PR DESCRIPTION
fix a couple misspellings of glyph in the readme.  Only changed in .Rmd assuming they will flow through to .md and elsewhere.