### PR TITLE
improve error message on font not found

### DIFF
--- a/R/waffle.R
+++ b/R/waffle.R
@@ -109,7 +109,7 @@ waffle <- function(parts, rows=10, xlab=NULL, title=NULL, colors=NA,
   } else {
 
     if (choose_font("FontAwesome", quiet=TRUE) == "") {
-      stop("FontAwesome not found. Install via: https://github.com/FortAwesome/Font-Awesome/tree/master/fonts",
+      stop('FontAwesome not found. Install via: font_import(system.file("fonts",package="waffle"),pattern="fontawesome-webfont.ttf")',
            call.=FALSE)
     }
 


### PR DESCRIPTION
Provide the specific command in R to install FontAwesome.  Since the font is included in `waffle`, most users should be able to do this to fix the "font not found".

```
font_import(system.file("fonts",package="waffle"),pattern="fontawesome-webfont.ttf")
```
