### PR TITLE
Corrected label on household debt plot

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -6,7 +6,8 @@ Date: 2018-04-04
 Authors@R: c(
     person("Bob", "Rudis", email = "bob@rud.is", role = c("aut", "cre"), 
            comment = c(ORCID = "0000-0001-5670-2640")),
-    person("Dave", "Gandy", role = "aut", comment = "Font Awesome")
+    person("Dave", "Gandy", role = "aut", comment = "Font Awesome"),
+    person("Andrew", "Breza", email = "andrew.breza@gmail.com", role = "ctb")
   )
 Maintainer: Bob Rudis <bob@rud.is>
 Description: Square pie charts (a.k.a. waffle charts) can be used

--- a/README.Rmd
+++ b/README.Rmd
@@ -142,7 +142,7 @@ waffle(
 ```
 
 
-**Average Household Savings Each Year**
+**Average Household Debt**
 ```{r fig4a, echo=FALSE, fig.width=8, fig.height=2.5}
 waffle(
   savings / 392, rows = 7, size = 0.5, legend_pos = "bottom",

--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ waffle(
 )
 ```
 
-**Average Household Savings Each Year**
+**Average Household Debt**
 <img src="README_files/figure-gfm/fig4a-1.png" width="768" />
 
 <span style="font-size:8pt">(1 square == $392)</span>


### PR DESCRIPTION
I'm unable to knit the .Rmd due to the problem flagged in issue #45. I fixed the description of the waffle plot about household debt. The chart shows debt levels, not annual savings.