### PR TITLE
add flip option to geom_waffle

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -6,7 +6,9 @@ Date: 2018-04-04
 Authors@R: c(
     person("Bob", "Rudis", email = "bob@rud.is", role = c("aut", "cre"), 
            comment = c(ORCID = "0000-0001-5670-2640")),
-    person("Dave", "Gandy", role = "aut", comment = "Font Awesome")
+    person("Dave", "Gandy", role = "aut", comment = "Font Awesome"),
+    person("Paul", "Campbell", email = "pacampbell91@gmail.com", 
+           role = "ctb", comment = "geom_bar flip")
   )
 Maintainer: Bob Rudis <bob@rud.is>
 Description: Square pie charts (a.k.a. waffle charts) can be used

--- a/R/geom-waffle.R
+++ b/R/geom-waffle.R
@@ -10,7 +10,8 @@
 #'   default), it is combined with the default mapping at the top level of the
 #'   plot. You must supply `mapping` if there is no plot mapping.
 #' @param n_rows how many rows should there be in the waffle chart? default is 10
-#' @param flip if TRUE, flip x and y coords. n_rows then becomes n_cols. useful to acheieve waffle column chart effect.
+#' @param flip If `TRUE`, flip x and y coords. n_rows then becomes n_cols.
+#'     Useful to achieve waffle column chart effect. Defaults is `FALSE`.
 #' @param make_proportional compute proportions from the raw values? (i.e. each
 #'        value `n` will be replaced with `n`/`sum(n)`); default is `FALSE`.
 #' @param data The data to be displayed in this layer. There are three
@@ -97,7 +98,7 @@ GeomWaffle <- ggplot2::ggproto(
     }
 
     # reduce all values by 0.5
-    # this allows for axis ticks to align _between_ square rows/cols 
+    # this allows for axis ticks to align _between_ square rows/cols
     # rather than in the middle of a row/col
     waf.dat$x <- waf.dat$x - .5
     waf.dat$y <- waf.dat$y - .5

--- a/README.Rmd
+++ b/README.Rmd
@@ -72,6 +72,36 @@ ggplot(xdf, aes(fill=parts, values=values)) +
   theme_enhance_waffle()
 ```
 
+### Waffle Bar Charts with scales!
+
+```{r waffle-bars, fig.retina=2}
+library(dplyr)
+library(waffle)
+
+storms %>% 
+  filter(year >= 2010) %>% 
+  count(year, status) -> storms_df
+
+ggplot(storms_df, aes(fill = status, values = n)) + 
+  geom_waffle(color = "white", size = .25, n_rows = 10, flip = TRUE) +
+  facet_wrap(~year, nrow = 1, strip.position = "bottom") +
+  scale_x_discrete() + 
+  scale_y_continuous(labels = function(x) x * 10, # make this multiplyer the same as n_rows
+                     expand = c(0,0)) +
+  ggthemes::scale_fill_tableau(name=NULL) +
+  coord_equal() +
+  labs(
+    title = "Faceted Waffle Bar Chart",
+    subtitle = "{dplyr} storms data",
+    x = "Year",
+    y = "Count"
+  ) +
+  theme_minimal(base_family = "Roboto Condensed") +
+  theme(panel.grid = element_blank(), axis.ticks.y = element_line()) +
+  guides(fill = guide_legend(reverse = TRUE))
+```
+
+
 ### Basic example
 
 ```{r fig0, fig.width=6, fig.height=2.5}


### PR DESCRIPTION
A couple changes to allow for faceted vertical waffle bars with axis ticks aligned appropriately. 

I added an example in `README.Rmd` but couldn't get it to knit due to some fontawesome installation issues!

Cheers,
Paul 