### PR TITLE
Add missing indent so package builds

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -11,7 +11,7 @@ Authors@R: c(
     person("Matthias", "Jütte", role = "ctb"),
     person("Paul", "Campbell", email = "pacampbell91@gmail.com", 
            role = "ctb", comment = "geom_bar flip")
-)
+    )
 Maintainer: Bob Rudis <bob@rud.is>
 Description: Square pie charts (a.k.a. waffle charts) can be used
     to communicate parts of a whole for categorical quantities. To emulate the


### PR DESCRIPTION
Trying to install from GitHub returns the following error:
```
> remotes::install_github('hrbrmstr/waffle') 
Error in read.dcf(path) : Line starting ') ...' is malformed!
```

Trying to build package returns:
```
ERROR: Package build failed.

Failed to parse DESCRIPTION: file line number 14 is invalid
```

Adding an indent at the beginning of line 14 in DESCRIPTION fixes error and package builds as normal.