### PR TITLE
Tile layout improvement: makes parts contiguous

### DIFF
--- a/R/stat-waffle.R
+++ b/R/stat-waffle.R
@@ -115,6 +115,7 @@ StatWaffle <- ggplot2::ggproto(
         x = seq_len((ceiling(sum(.x[["values"]]) / params$n_rows)))#,
         # stringsAsFactors = FALSE
       ) -> tdf
+      tdf <- snake_sort_grid(tdf)
 
       parts_vec <- c(parts_vec, rep(NA, nrow(tdf)-length(parts_vec)))
       colour_vec <- c(colour_vec, rep(NA, nrow(tdf)-length(colour_vec)))

--- a/R/utils.r
+++ b/R/utils.r
@@ -88,6 +88,14 @@ insert_unit <- function (x, values, after = length(x)) {
 
 }
 
+# order an expand.grid alternatingly, providing a better layout for waffle
+snake_sort_grid <- function(grid){
+  y <- grid[[1]]
+  x <- grid[[2]]
+  o <- order(x, ifelse(x%%2 > 0, y, -y))
+  grid[o,]
+}
+
 # Name ggplot grid object
 # Convenience function to name grid objects
 #

--- a/R/waffle.R
+++ b/R/waffle.R
@@ -120,6 +120,9 @@ waffle <- function(parts, rows=10, keep=TRUE, xlab=NULL, title=NULL, colors=NA,
   # setup the data frame for geom_rect
   dat <- expand.grid(y = 1:rows, x = seq_len(pad + (ceiling(sum(parts) / rows))))
 
+  # order the grid snake wise...
+  dat <- snake_sort_grid(dat)
+
   # add NAs if needed to fill in the "rectangle"
   dat$value <- c(parts_vec, rep(NA, nrow(dat) - length(parts_vec)))
 


### PR DESCRIPTION
Thanks for this package! 

I ran into a layout issue with a data set of mine which is shown in the following example:

```r
parts <- tapply(iris$Sepal.Length, iris$Species, mean)
waffle(parts, rows = 7)
```
which results in:

![waffle](https://user-images.githubusercontent.com/542492/63431939-570d5580-c420-11e9-9020-b3cfec738a90.png)

I provided a fix by sorting the even rows of the expanded grid in the opposite direction of the odd rows.  ("snake_sort"?), resulting in contiguous parts:

![waffle2](https://user-images.githubusercontent.com/542492/63432078-a6ec1c80-c420-11e9-8051-50c8445f78d4.png)


I suppose this is related to issue #32. 