### PR TITLE
Return directory invisibly from install_fa_fonts

### DIFF
--- a/R/fontawesome.R
+++ b/R/fontawesome.R
@@ -49,6 +49,7 @@ install_fa_fonts <- function() {
     "\n\nPlease navigate to that directory and install them on ",
     "your system."
   )
+  invisible(system.file("fonts", package = "waffle"))
 }
 
 #' Font Awesome 5 Solid


### PR DESCRIPTION
If you return the font directory invisibly from install_fa_fonts(), it makes it easier to write code that makes a script reproducible on different machines. E.g.:

```
fontdir <- install_fa_fonts()
sysfonts::font_add(family = fa5_brand, regular = paste0(fontdir, "fa-brands-400.ttf"))
sysfonts::font_add(family = fa5_solid, regular = paste0(fontdir, "fa-solid-900.ttf"))
showtext::showtext_auto()
```