### PR TITLE
Get rid of axis ticks for theme_enhance_waffle()

### DIFF
--- a/R/waffle-enhance.R
+++ b/R/waffle-enhance.R
@@ -22,6 +22,7 @@ theme_enhance_waffle<- function() {
   ret <- ret + theme(axis.title.y = element_blank())
   ret <- ret + theme(axis.title.y.left = element_blank())
   ret <- ret + theme(axis.title.y.right = element_blank())
+  ret <- ret + theme(axis.ticks = element_blank())
 
   ret
 


### PR DESCRIPTION
I can't see how the axis ticks would ever be wanted in a waffle plot.