### PR TITLE
Roxygen2 and version updates

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: waffle
 Type: Package
 Title: Create Waffle Chart Visualizations
-Version: 1.0.2
-Date: 2023-09-30
+Version: 1.0.3
+Date: 2025-10-27
 Authors@R: c(
     person("Bob", "Rudis", email = "bob@rud.is", role = c("aut", "cre"), 
            comment = c(ORCID = "0000-0001-5670-2640")),
@@ -47,4 +47,4 @@ Imports:
     plyr,
     rlang,
     utils
-RoxygenNote: 7.2.3
+RoxygenNote: 7.3.3

--- a/R/waffle-package.R
+++ b/R/waffle-package.R
@@ -7,7 +7,7 @@
 #' URL: http://scripts.sil.org/OFL
 #'
 #' @name waffle-package
-#' @docType package
+"_PACKAGE"
 #' @import gridExtra
 #' @import stringr
 #' @import curl

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ The following functions are implemented:
 ## Installation
 
 ``` r
-install.packages("waffle") # NOTE: CRAN version is 0.7.0
+install.packages("waffle") # NOTE: Not available as at 2025/10/27
 # or
 remotes::install_github("hrbrmstr/waffle")
 ```

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ library(waffle)
 
 # current verison
 packageVersion("waffle")
-## [1] '1.0.2'
+## [1] '1.0.3'
 ```
 
 ### Some new bits up first

--- a/README.md
+++ b/README.md
@@ -63,7 +63,6 @@ NOTE: To use the ‘remotes’ install options you will need to have the
 ``` r
 library(waffle)
 library(magrittr)
-library(hrbrthemes)
 library(ggplot2)
 library(dplyr)
 library(waffle)

--- a/man/waffle-package.Rd
+++ b/man/waffle-package.Rd
@@ -11,3 +11,19 @@ Font Awesome by Dave Gandy - http://fontawesome.io\cr
 License: SIL OFL 1.1\cr
 URL: http://scripts.sil.org/OFL
 }
+\author{
+\strong{Maintainer}: Bob Rudis \email{bob@rud.is} (\href{https://orcid.org/0000-0001-5670-2640}{ORCID})
+
+Authors:
+\itemize{
+  \item Dave Gandy (Font Awesome)
+}
+
+Other contributors:
+\itemize{
+  \item Andrew Breza \email{andrew.breza@gmail.com} [contributor]
+  \item Matthias Jütte [contributor]
+  \item Paul Campbell \email{pacampbell91@gmail.com} (geom_bar flip) [contributor]
+}
+
+}


### PR DESCRIPTION
I've updated the roxygen version and changed line 10 of "waffle-package.R" for the CMD check, bumped the version number for CRAN, and updated README.md slightly to remove reference to an old dependency, `hrbrthemes`, and reflect the package isn't currently on CRAN. I _think_ that should allow the package to be resubmitted to CRAN, per the removal highlighted in #101.